### PR TITLE
fix(eslint-config): disable import rules

### DIFF
--- a/.changeset/wide-bats-sneeze.md
+++ b/.changeset/wide-bats-sneeze.md
@@ -1,0 +1,10 @@
+---
+"@vp-tw/eslint-config": patch
+"test-react": patch
+---
+
+disable import rules
+
+`eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+
+See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)

--- a/packages/eslint-config/src/configs/mdx.ts
+++ b/packages/eslint-config/src/configs/mdx.ts
@@ -3,7 +3,6 @@ import type { ConfigOverrides, TypedFlatConfigItem } from "../types";
 import {
   ensurePackages,
   GLOB_MARKDOWN,
-  GLOB_MARKDOWN_CODE,
   interopDefault,
 } from "@antfu/eslint-config";
 import { omit, pick } from "es-toolkit";
@@ -64,17 +63,22 @@ const mdx = async ({
   if (codeBlocks) {
     const codeBlocksConfig = mergeConfig(
       codeBlocksOptions,
-      {
-        rules: {
-          "import/no-default-export": "off",
-        },
-        ignores: [
-          /**
-           * Handled by `@eslint/markdown`.
-           */
-          GLOB_MARKDOWN_CODE,
-        ],
-      },
+      /**
+       * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+       *
+       * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
+       */
+      // {
+      //   rules: {
+      //     "import/no-default-export": "off",
+      //   },
+      //   ignores: [
+      //     /**
+      //      * Handled by `@eslint/markdown`.
+      //      */
+      //     GLOB_MARKDOWN_CODE,
+      //   ],
+      // },
       {
         ...mdxPlugin.flatCodeBlocks,
         name: "vdustr/mdx/code-blocks",

--- a/packages/eslint-config/src/configs/storybook.ts
+++ b/packages/eslint-config/src/configs/storybook.ts
@@ -36,7 +36,12 @@ const storybook = async (
     {
       name: "vdustr/storybook/stories/rules",
       rules: {
-        "import/no-default-export": "off",
+        /**
+         * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+         *
+         * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
+         */
+        // "import/no-default-export": "off",
       },
     },
     {

--- a/packages/eslint-config/src/extends/imports.ts
+++ b/packages/eslint-config/src/extends/imports.ts
@@ -37,15 +37,20 @@ const imports = (composer: VpComposer, options?: imports.Options) => {
         name: "vdustr/imports/rules",
         rules: {
           /**
-           * Forbid `import {} from "module"`.
+           * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+           *
+           * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
            */
-          "import/no-empty-named-blocks": "error",
-
-          /**
-           * Wildcard imports can prevent tree shaking and cause name conflicts.
-           * Consider using named imports instead.
-           */
-          "import/no-namespace": "error",
+          // /**
+          //  * Forbid `import {} from "module"`.
+          //  */
+          // "import/no-empty-named-blocks": "error",
+          //
+          // /**
+          //  * Wildcard imports can prevent tree shaking and cause name conflicts.
+          //  * Consider using named imports instead.
+          //  */
+          // "import/no-namespace": "error",
         },
       },
       omittedConfig,
@@ -56,12 +61,17 @@ const imports = (composer: VpComposer, options?: imports.Options) => {
         name: "vdustr/imports/no-default-export/rules",
         rules: {
           /**
+           * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+           *
+           * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
+           */
+          /**
            * Enforcing named exports improves consistency, enhances
            * auto-completion and refactoring, and avoids issues with default
            * export renaming. Additionally, default exports might lead to
            * different behavior when transformed to CJS.
            */
-          "import/no-default-export": "error",
+          // "import/no-default-export": "error",
         },
         files: [GLOB_JS, GLOB_JSX, GLOB_TS, GLOB_TSX],
         ignores: [

--- a/packages/test-js/.dot/index.js
+++ b/packages/test-js/.dot/index.js
@@ -1,4 +1,9 @@
-// eslint-disable-next-line import/no-empty-named-blocks -- `import/no-empty-named-blocks` should validate this.
+/**
+ * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+ *
+ * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
+ */
+// #eslint-disable-next-line import/no-empty-named-blocks -- `import/no-empty-named-blocks` should validate this.
 import {} from "node:path";
 // eslint-disable-next-line unicorn/prefer-node-protocol -- `unicorn` should validate this.
 import path from "path";

--- a/packages/test-js/index.js
+++ b/packages/test-js/index.js
@@ -1,4 +1,9 @@
-// eslint-disable-next-line import/no-empty-named-blocks -- `import/no-empty-named-blocks` should validate this.
+/**
+ * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+ *
+ * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
+ */
+// #eslint-disable-next-line import/no-empty-named-blocks -- `import/no-empty-named-blocks` should validate this.
 import {} from "node:path";
 // eslint-disable-next-line unicorn/prefer-node-protocol -- `unicorn` should validate this.
 import path from "path";

--- a/packages/test-react/MyComponent.tsx
+++ b/packages/test-react/MyComponent.tsx
@@ -9,7 +9,13 @@ import {
   useRef,
   useState,
 } from "react";
-// eslint-disable-next-line import/no-namespace -- `import/no-namespace` should validate this.
+
+/**
+ * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+ *
+ * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
+ */
+// #eslint-disable-next-line import/no-namespace -- `import/no-namespace` should validate this.
 import * as React from "react";
 
 // eslint-disable-next-line @emotion/syntax-preference -- Styles should be written using objects.
@@ -83,7 +89,12 @@ const MyComponent: React.FC<MyComponent.Props> = (props) => {
 
 const A: React.FC = () => "a";
 
-// eslint-disable-next-line import/no-default-export -- `import/no-default-export` should validate this.
+/**
+ * `eslint-plugin-import-x` has been removed from `antfu/eslint-config`.
+ *
+ * See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)
+ */
+// #eslint-disable-next-line import/no-default-export -- `import/no-default-export` should validate this.
 export default MyComponent;
 
 export {


### PR DESCRIPTION
`eslint-plugin-import-x` has been removed from `antfu/eslint-config`.

See: [fix: remove eslint-plugin-import-x](https://github.com/antfu/eslint-config/commit/db5a31d)

Fix GitHub Action failure: [ci: changeset release (#10) #1 > Release](https://github.com/VdustR/eslint-config/actions/runs/15723875070/job/44309883830)

# Copilot

This pull request primarily addresses the removal of `eslint-plugin-import-x` from `antfu/eslint-config` and updates related configurations and comments across multiple files. The changes ensure compatibility with the updated ESLint configuration and improve clarity by annotating deprecated rules.

### Removal of `eslint-plugin-import-x`:

* [`.changeset/wide-bats-sneeze.md`](diffhunk://#diff-1c8b3cd440155cd98bb66e33da628be416021c0d9d1333dfe3b71cbf498584a7R1-R10): Documented the removal of `eslint-plugin-import-x` and its associated rules from `antfu/eslint-config`.

### Updates to ESLint configuration files:

* [`packages/eslint-config/src/configs/mdx.ts`](diffhunk://#diff-91bfe82f03843b9a234bc8bdb690682583501463e5d0adca8101112dd6043589L6): Removed references to deprecated rules like `import/no-default-export` and `GLOB_MARKDOWN_CODE`, replacing them with comments explaining the removal of `eslint-plugin-import-x`. [[1]](diffhunk://#diff-91bfe82f03843b9a234bc8bdb690682583501463e5d0adca8101112dd6043589L6) [[2]](diffhunk://#diff-91bfe82f03843b9a234bc8bdb690682583501463e5d0adca8101112dd6043589L67-R81)
* [`packages/eslint-config/src/configs/storybook.ts`](diffhunk://#diff-46201773206cf37a7fba4308fcc99755cdd7a34ff0e36c15f59cabe03a973e08L39-R44): Commented out the rule `import/no-default-export` and added annotations about the removal of `eslint-plugin-import-x`.
* [`packages/eslint-config/src/extends/imports.ts`](diffhunk://#diff-0a7f41a7a52222e003c1a0d5980fee7a26acbc0fa5e9e515b3016d53834944d6L40-R53): Disabled rules such as `import/no-empty-named-blocks`, `import/no-namespace`, and `import/no-default-export`, adding comments to explain their deprecation due to the removal of `eslint-plugin-import-x`. [[1]](diffhunk://#diff-0a7f41a7a52222e003c1a0d5980fee7a26acbc0fa5e9e515b3016d53834944d6L40-R53) [[2]](diffhunk://#diff-0a7f41a7a52222e003c1a0d5980fee7a26acbc0fa5e9e515b3016d53834944d6R63-R74)

### Updates to test files:

* `packages/test-js/.dot/index.js` and `packages/test-js/index.js`: Annotated the disabled rule `import/no-empty-named-blocks` with comments about the removal of `eslint-plugin-import-x`.
* [`packages/test-react/MyComponent.tsx`](diffhunk://#diff-2dbd03ad8e704e489554d111e92d5442874e9cf18d10d1f2d8f2c371f67a238dL12-R18): Updated comments for disabled rules `import/no-namespace` and `import/no-default-export`, reflecting the removal of `eslint-plugin-import-x`. [[1]](diffhunk://#diff-2dbd03ad8e704e489554d111e92d5442874e9cf18d10d1f2d8f2c371f67a238dL12-R18) [[2]](diffhunk://#diff-2dbd03ad8e704e489554d111e92d5442874e9cf18d10d1f2d8f2c371f67a238dL86-R97)