### PR TITLE
build(eslint-config): copy first then build

### DIFF
--- a/.changeset/tender-melons-train.md
+++ b/.changeset/tender-melons-train.md
@@ -1,0 +1,7 @@
+---
+"@vp-tw/eslint-config": patch
+---
+
+copy first then build
+
+Fix GitHub Actions failure: [build: bump version (#12) #3 > Release](https://github.com/VdustR/eslint-config/actions/runs/15724249016/job/44310932884)

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -43,7 +43,7 @@
     "build": "unbuild",
     "copy": "tsx scripts/copy",
     "prepare": "run-s typegen",
-    "prepublishOnly": "run-s build copy",
+    "prepublishOnly": "run-s copy build",
     "typegen": "jiti scripts/typegen"
   },
   "dependencies": {


### PR DESCRIPTION

copy first then build

Fix GitHub Actions failure: [build: bump version (#12) #3 > Release](https://github.com/VdustR/eslint-config/actions/runs/15724249016/job/44310932884)

# Copilot

This pull request addresses a GitHub Actions failure related to the build process by modifying the order of operations in the `prepublishOnly` script. Additionally, it includes a changeset to document the fix and bump the package version.

### Build process fix:

* [`.changeset/tender-melons-train.md`](diffhunk://#diff-5eb5c48a18b84fe91429d881243ed75048aa621a9d1562fe48c58c83ca7135c8R1-R7): Added a changeset to document the fix for the GitHub Actions failure and bump the version of `@vp-tw/eslint-config`.
* [`packages/eslint-config/package.json`](diffhunk://#diff-b398e019411e81059801ebf7fe19f6ebcad0bc316fd5c0449d8acdbee9d6d5deL46-R46): Adjusted the `prepublishOnly` script to execute the `copy` command before `build`, ensuring the correct order of operations to resolve the failure.